### PR TITLE
Only import necessary firebase modules

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -1,4 +1,5 @@
-import * as firebase from 'firebase';
+import * as firebase from 'firebase/app';
+import 'firebase/firestore';
 import { firebaseConfig } from '../environments/firebase';
 
 export const db = firebase.initializeApp(firebaseConfig).firestore();

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -1,4 +1,5 @@
-import * as firebase from 'firebase';
+import * as firebase from 'firebase/app';
+import 'firebase/auth';
 
 import AuthorizationError from '@/components/AuthorizationError.vue';
 import Years from '@/components/Years.vue';


### PR DESCRIPTION
Instead of importing the whole firebase package, we now only import the
modules necessary for the application to work.