### PR TITLE
Remember selected participant

### DIFF
--- a/src/components/Predictions.vue
+++ b/src/components/Predictions.vue
@@ -19,7 +19,7 @@
           label="name"
           :options="participants"
           :searchable="false"
-          :on-change="participantChanged"
+          @input="participantChanged"
         ></v-select>
       </div>
 


### PR DESCRIPTION
The upgrade from `vue-select` 2 to 3 contained a breaking change,
replacing the `onChange` callback with the `input` event.

The usage of `v-select` has now been updated to properly reflect that.