### PR TITLE
Add admin interface for updating prediction outcomes

### DIFF
--- a/src/components/Admin.vue
+++ b/src/components/Admin.vue
@@ -1,0 +1,105 @@
+<template>
+  <div id="admin">
+    <Navigation :years="years" />
+    <div v-if="!isEmailUser" class="admin-content">
+      <AdminLogin />
+    </div>
+    <div v-else class="admin-content">
+      <h1>Admin</h1>
+      <div class="admin-controls">
+        <select v-model="selectedYearId" class="year-select">
+          <option disabled value="">Vælg år</option>
+          <option v-for="year in years" :key="year.id" :value="year.id">
+            {{ year.id }}
+          </option>
+        </select>
+        <button class="logout-button" @click="logout">Log ud</button>
+      </div>
+      <AdminQuestions v-if="selectedYearId" :yearId="selectedYearId" />
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import * as firebase from 'firebase/app';
+import 'firebase/auth';
+import 'firebase/firestore';
+
+import AdminLogin from '@/components/admin/AdminLogin.vue';
+import AdminQuestions from '@/components/admin/AdminQuestions.vue';
+import Navigation from '@/components/Navigation.vue';
+import { db } from '@/db';
+import { Year } from '@/interfaces/year';
+import { Component, Vue } from 'vue-property-decorator';
+
+@Component({
+  data() {
+    return {
+      years: [],
+      isEmailUser: false,
+      selectedYearId: ''
+    };
+  },
+  components: {
+    Navigation,
+    AdminLogin,
+    AdminQuestions
+  },
+  firestore: {
+    years: db.collection('years')
+  }
+})
+export default class Admin extends Vue {
+  private years!: Year[];
+  private isEmailUser!: boolean;
+  private selectedYearId!: string;
+  private unsubscribeAuth: (() => void) | null = null;
+
+  public created(): void {
+    this.unsubscribeAuth = firebase.auth().onAuthStateChanged(user => {
+      this.isEmailUser = !!(user && user.email);
+    });
+  }
+
+  public beforeDestroy(): void {
+    if (this.unsubscribeAuth) {
+      this.unsubscribeAuth();
+    }
+  }
+
+  public async logout(): Promise<void> {
+    await firebase.auth().signOut();
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+.admin-content {
+  max-width: 700px;
+  margin: 0 auto;
+  padding: 0 16px;
+}
+
+.admin-controls {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 24px;
+}
+
+.year-select {
+  padding: 8px;
+  font-size: 1em;
+  border: 1px solid rgba(0, 0, 0, 0.3);
+  border-radius: 4px;
+}
+
+.logout-button {
+  padding: 8px 16px;
+  background: transparent;
+  border: 1px solid rgba(0, 0, 0, 0.3);
+  border-radius: 4px;
+  font-size: 1em;
+  cursor: pointer;
+}
+</style>

--- a/src/components/Navigation.vue
+++ b/src/components/Navigation.vue
@@ -7,6 +7,8 @@
       </a>
       <h1>Statistik</h1>
       <a href="#/stats/"><span>Oversigt</span></a>
+      <h1>Admin</h1>
+      <a href="#/admin"><span>Admin</span></a>
     </Slide>
   </div>
 </template>

--- a/src/components/admin/AdminLogin.vue
+++ b/src/components/admin/AdminLogin.vue
@@ -1,0 +1,62 @@
+<template>
+  <div class="admin-login">
+    <h1>Admin login</h1>
+    <p v-if="error" class="error">{{ error }}</p>
+    <button :disabled="loading" @click="login">Log ind med Google</button>
+  </div>
+</template>
+
+<script lang="ts">
+import * as firebase from 'firebase/app';
+import 'firebase/auth';
+import { adminEmail } from '../../../environments/firebase';
+import { Component, Vue } from 'vue-property-decorator';
+
+@Component
+export default class AdminLogin extends Vue {
+  private error: string = '';
+  private loading: boolean = false;
+
+  public async login(): Promise<void> {
+    this.error = '';
+    this.loading = true;
+    try {
+      const result = await firebase.auth().signInWithPopup(new firebase.auth.GoogleAuthProvider());
+      if (result.user?.email !== adminEmail) {
+        await firebase.auth().signOut();
+        this.error = 'Ingen adgang.';
+      }
+    } catch (e: any) {
+      this.error = e.message;
+    } finally {
+      this.loading = false;
+    }
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+.admin-login {
+  max-width: 360px;
+  margin: 60px auto;
+
+  .error {
+    color: #c00;
+  }
+
+  button {
+    padding: 10px 20px;
+    background: #333;
+    color: #fff;
+    border: none;
+    border-radius: 4px;
+    font-size: 1em;
+    cursor: pointer;
+
+    &:disabled {
+      opacity: 0.5;
+      cursor: default;
+    }
+  }
+}
+</style>

--- a/src/components/admin/AdminQuestions.vue
+++ b/src/components/admin/AdminQuestions.vue
@@ -1,0 +1,114 @@
+<template>
+  <div class="admin-questions">
+    <div v-for="(question, index) in questions" :key="question.id" class="question-row">
+      <span class="question-index">{{ index + 1 }}.</span>
+      <span class="question-text">{{ question.question }}</span>
+      <div class="outcome-buttons">
+        <button
+          v-for="option in outcomeOptions"
+          :key="option.value"
+          :class="{ active: question.outcome === option.value }"
+          @click="setOutcome(question, option.value)"
+        >
+          {{ option.label }}
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { db } from '@/db';
+import { Question } from '@/interfaces/question';
+import { Component, Prop, Vue } from 'vue-property-decorator';
+
+import 'firebase/firestore';
+
+const years = db.collection('years');
+
+const outcomeOptions = [
+  { label: 'Ja', value: 1 },
+  { label: 'Nej', value: 0 },
+  { label: 'Ukendt', value: -1 }
+];
+
+@Component({
+  data() {
+    return {
+      questions: [],
+      outcomeOptions
+    };
+  },
+  watch: {
+    yearId: {
+      immediate: true,
+      handler(this: AdminQuestions, yearId: string) {
+        this.$bind('questions', years.doc(yearId).collection('questions'));
+      }
+    }
+  }
+})
+export default class AdminQuestions extends Vue {
+  @Prop() private yearId!: string;
+
+  public setOutcome(question: Question, outcome: number): void {
+    years
+      .doc(this.yearId)
+      .collection('questions')
+      .doc(question.id)
+      .update({ outcome });
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+.admin-questions {
+  max-width: 700px;
+  margin: 0 auto;
+}
+
+.question-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 8px 0;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.1);
+
+  &:last-child {
+    border-bottom: none;
+  }
+}
+
+.question-index {
+  font-weight: 600;
+  min-width: 24px;
+  text-align: right;
+  flex-shrink: 0;
+}
+
+.question-text {
+  flex: 1;
+  text-align: left;
+}
+
+.outcome-buttons {
+  display: flex;
+  gap: 6px;
+  flex-shrink: 0;
+
+  button {
+    padding: 4px 12px;
+    border: 1px solid rgba(0, 0, 0, 0.3);
+    border-radius: 4px;
+    background: #fff;
+    cursor: pointer;
+    font-size: 0.9em;
+
+    &.active {
+      background: #333;
+      color: #fff;
+      border-color: #333;
+    }
+  }
+}
+</style>

--- a/src/interfaces/question.ts
+++ b/src/interfaces/question.ts
@@ -1,4 +1,5 @@
 export interface Question {
+  id: string;
   question: string;
   outcome: number;
 }

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -1,6 +1,7 @@
 import * as firebase from 'firebase/app';
 import 'firebase/auth';
 
+import Admin from '@/components/Admin.vue';
 import AuthorizationError from '@/components/AuthorizationError.vue';
 import Stats from '@/components/Stats.vue';
 import Years from '@/components/Years.vue';
@@ -10,6 +11,7 @@ import VueRouter from 'vue-router';
 Vue.use(VueRouter);
 
 const routes = [
+  { path: '/admin', component: Admin },
   { path: '/years/:year', component: Years },
   { path: '/years/', component: Years },
   { path: '/stats/', component: Stats },


### PR DESCRIPTION
## Summary

- Adds `/admin` route with Google Sign-In authentication
- Only the admin email configured in `environments/firebase.ts` can access the editor
- Admin can select a year and update each question's outcome (Ja/Nej/Ukendt) directly from the app
- Unauthorized Google accounts are signed out immediately with an error message

## New files
- `src/components/Admin.vue` — top-level admin route, handles auth state
- `src/components/admin/AdminLogin.vue` — Google Sign-In button
- `src/components/admin/AdminQuestions.vue` — question list with outcome buttons

## Manual steps required
- Firebase Console: enable Google Sign-In provider
- Firestore rules: restrict writes to admin email only
  ```
  allow write: if request.auth.token.email == 'your-admin@gmail.com';
  ```

## Test plan
- [ ] Navigate to `/#/admin` as anonymous user → login button shown
- [ ] Sign in with non-admin Google account → "Ingen adgang" error shown
- [ ] Sign in with admin account → year selector and questions appear
- [ ] Click outcome buttons → Firestore updates in Firebase Console
- [ ] Refresh page → admin session persists
- [ ] Log ud → login button returns