### PR TITLE
Reduce burger menu button size

### DIFF
--- a/src/components/Navigation.vue
+++ b/src/components/Navigation.vue
@@ -52,6 +52,13 @@ export default class Navigation extends Vue {
   background: var(--color-surface) !important;
 }
 
+.bm-burger-button {
+  width: 22px !important;
+  height: 18px !important;
+  top: 18px !important;
+  left: 18px !important;
+}
+
 .bm-burger-bars {
   background-color: var(--color-text-muted) !important;
 }


### PR DESCRIPTION
## Summary
- Overrides `vue-burger-menu` default `.bm-burger-button` styles to shrink the button from 36×30px to 22×18px
- Moves the button closer to the corner (top/left: 18px instead of 36px) so it sits naturally within the layout

## Test plan
- [ ] Open the app on mobile and verify the burger button looks proportional to the rest of the header
- [ ] Tap the button to confirm the menu still opens correctly
- [ ] Check desktop view to ensure no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)