### PR TITLE
Add tie-breakers to leaderboard scoring

### DIFF
--- a/src/components/Predictions.vue
+++ b/src/components/Predictions.vue
@@ -77,9 +77,17 @@ export default class Predictions extends Vue {
     if (!this.participants) {
       return [];
     }
-    return [...this.participants].sort(
-      (a, b) => this.correctAnswers(b) - this.correctAnswers(a)
-    );
+    return [...this.participants].sort((a, b) => {
+      const correctDiff = this.correctAnswers(b) - this.correctAnswers(a);
+      if (correctDiff !== 0) {
+        return correctDiff;
+      }
+      const yesDiff = this.yesPredictions(b) - this.yesPredictions(a);
+      if (yesDiff !== 0) {
+        return yesDiff;
+      }
+      return this.correctYesAnswers(b) - this.correctYesAnswers(a);
+    });
   }
 
   public get determinedOutcome(): number {
@@ -142,6 +150,20 @@ export default class Predictions extends Vue {
       prediction
         ? this.questions[index].outcome === 1
         : this.questions[index].outcome === 0
+    ).length;
+  }
+
+  public yesPredictions(participant: Participant): number {
+    return participant.predictions.filter(prediction => prediction).length;
+  }
+
+  public correctYesAnswers(participant: Participant): number {
+    if (isEmpty(this.questions)) {
+      return 0;
+    }
+    return participant.predictions.filter(
+      (prediction, index) =>
+        prediction && this.questions[index].outcome === 1
     ).length;
   }
 


### PR DESCRIPTION
## Summary
- When participants are tied on correct answers, rank by most "yes" predictions made (regardless of outcome)
- If still tied, rank by most correct "yes" predictions

## Test plan
- [x] `npm run lint` passes
- [ ] Manually verify leaderboard ordering with tied participants in the app